### PR TITLE
Fix ComponentXNode resolving

### DIFF
--- a/example_project/example/templates/example/templatetags.html
+++ b/example_project/example/templates/example/templatetags.html
@@ -154,6 +154,14 @@
                 {% endgds_summary_list_row %}
             {% endgds_summary_list %}
             {% gds_summary_list %}
+                {% for user in users %}
+                    {% gds_summary_list_row %}
+                        {% gds_summary_list_row_key_inline text=user.username %}
+                        {% gds_summary_list_row_value_inline text=user.email %}
+                    {% endgds_summary_list_row %}
+                {% endfor %}
+            {% endgds_summary_list %}
+            {% gds_summary_list %}
                 {% gds_summary_list_row %}
                     {% gds_summary_list_row_key_inline text="Key 1" %}
                     {% gds_summary_list_row_value_inline text="Value 1" %}

--- a/example_project/example/templates/example/templatetags.html
+++ b/example_project/example/templates/example/templatetags.html
@@ -154,11 +154,29 @@
                 {% endgds_summary_list_row %}
             {% endgds_summary_list %}
             {% gds_summary_list %}
+                {% if True %}
+                    {% gds_summary_list_row %}
+                        {% gds_summary_list_row_key_inline text="Component" %}
+                        {% gds_summary_list_row_value_inline text="IfNode" %}
+                    {% endgds_summary_list_row %}
+                {% endif %}
+            {% endgds_summary_list %}
+            {% gds_summary_list %}
                 {% for user in users %}
                     {% gds_summary_list_row %}
                         {% gds_summary_list_row_key_inline text=user.username %}
                         {% gds_summary_list_row_value_inline text=user.email %}
                     {% endgds_summary_list_row %}
+                {% endfor %}
+            {% endgds_summary_list %}
+            {% gds_summary_list %}
+                {% for user1 in users %}
+                    {% for user2 in users %}
+                        {% gds_summary_list_row %}
+                            {% gds_summary_list_row_key_inline text=user1.username %}
+                            {% gds_summary_list_row_value_inline text=user2.email %}
+                        {% endgds_summary_list_row %}
+                    {% endfor %}
                 {% endfor %}
             {% endgds_summary_list %}
             {% gds_summary_list %}

--- a/example_project/example/views.py
+++ b/example_project/example/views.py
@@ -101,6 +101,7 @@ def components_view(request):
             ("email", "Email"),
         ],
         model_table_rows=User.objects.all(),
+        users=User.objects.all(),
         nav_links=[
             (
                 "Link 1",

--- a/govuk_frontend_django/templatetags/govuk_frontend_django/__init__.py
+++ b/govuk_frontend_django/templatetags/govuk_frontend_django/__init__.py
@@ -1,6 +1,6 @@
 import importlib
 import pathlib
-from dataclasses import dataclass, is_dataclass
+from dataclasses import is_dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union, cast
 
 from django import template
@@ -30,23 +30,16 @@ SubDataclassDictWithOrWithoutNode = Union[DataclassDict, SubDataclassDictWithNod
 
 
 class ResolvingNode(Node):
-    add_sub_components: bool = True
-
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.sub_dataclasses: List[SubDataclassWithNode] = []
 
-    def clear(self):
+    def clear(self) -> None:
         self.sub_dataclasses = []
 
-    def resolve(
-        self,
-        context: Context,
-    ):
-        nodelist = getattr(self, "nodelist", NodeList())
-
+    def resolve_nodelist(self, nodelist: NodeList, context: Context) -> None:
         for node in nodelist:
-            if isinstance(node, GovUKComponentNode) and self.add_sub_components:
+            if isinstance(node, GovUKComponentNode):
                 dcls = node.resolve_dataclass(context, as_dict=False)
                 assert is_dataclass(dcls)
 
@@ -71,6 +64,13 @@ class ResolvingNode(Node):
                 node.resolve(context)
             if hasattr(node, "sub_dataclasses"):
                 self.sub_dataclasses.extend(node.sub_dataclasses)
+
+    def resolve(
+        self,
+        context: Context,
+    ) -> None:
+        nodelist = getattr(self, "nodelist", NodeList())
+        self.resolve_nodelist(nodelist, context)
 
     def get_sub_dataclasses_by_type(
         self,
@@ -124,23 +124,13 @@ class ComponentIfNode(ResolvingNode, IfNode):
                 match = True
 
             if match:
-                for node in nodelist:
-                    if hasattr(node, "resolve_dataclass"):
-                        assert isinstance(node, GovUKComponentNode)
-
-                        dcls = node.resolve_dataclass(context, as_dict=False)
-                        assert is_dataclass(dcls)
-
-                        dcls_with_node = cast(SubDataclassWithNode, (dcls, node))
-                        self.sub_dataclasses.append(dcls_with_node)
+                self.resolve_nodelist(nodelist, context)
 
 
 class ComponentForNode(ResolvingNode, ForNode):
     """
     Custom ForNode that will resolve the nodelist as per the loop.
     """
-
-    add_sub_components = False
 
     def resolve(self, context: Context, **kwargs):
         """
@@ -205,17 +195,7 @@ class ComponentForNode(ResolvingNode, ForNode):
 
                 assert isinstance(self.nodelist_loop, NodeList)
 
-                for node in self.nodelist_loop:
-                    if hasattr(node, "resolve_dataclass"):
-                        assert isinstance(node, GovUKComponentNode)
-
-                        dcls = node.resolve_dataclass(context, as_dict=False)
-                        assert is_dataclass(dcls)
-
-                        dcls_with_node = cast(SubDataclassWithNode, (dcls, node))
-                        self.sub_dataclasses.append(dcls_with_node)
-                    node.render_annotated(context)
-                    self.nodelist.append(node)
+                self.resolve_nodelist(self.nodelist_loop, context)
 
                 if pop_context:
                     # Pop the loop variables pushed on to the context to avoid

--- a/govuk_frontend_django/templatetags/govuk_frontend_django/__init__.py
+++ b/govuk_frontend_django/templatetags/govuk_frontend_django/__init__.py
@@ -30,6 +30,8 @@ SubDataclassDictWithOrWithoutNode = Union[DataclassDict, SubDataclassDictWithNod
 
 
 class ResolvingNode(Node):
+    add_sub_components: bool = True
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.sub_dataclasses: List[SubDataclassWithNode] = []
@@ -44,7 +46,7 @@ class ResolvingNode(Node):
         nodelist = getattr(self, "nodelist", NodeList())
 
         for node in nodelist:
-            if isinstance(node, GovUKComponentNode):
+            if isinstance(node, GovUKComponentNode) and self.add_sub_components:
                 dcls = node.resolve_dataclass(context, as_dict=False)
                 assert is_dataclass(dcls)
 
@@ -137,6 +139,8 @@ class ComponentForNode(ResolvingNode, ForNode):
     """
     Custom ForNode that will resolve the nodelist as per the loop.
     """
+
+    add_sub_components = False
 
     def resolve(self, context: Context, **kwargs):
         """


### PR DESCRIPTION
Issue:
The symptom was that when you put a for loop inside a for loop that is inside a GDS Component Template Tag, only the context of the most inner for loop is available.

The Fix:
Standardise and simplify the resolving logic so that we iterate the for loops inside the for loop passing the correct context down.